### PR TITLE
Always provide latest version.

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,17 +1,21 @@
 pkgbase = archisteamfarm-bin
 	pkgdesc = C# application that allows you to farm steam cards using multiple steam accounts simultaneously.
-	pkgver = 4.0.1.9
+	pkgver = 4.1.1.7
 	pkgrel = 1
 	url = https://github.com/JustArchiNET/ArchiSteamFarm
 	arch = x86_64
 	license = Apache License 2.0
 	makedepends = unzip
+	makedepends = curl
+	makedepends = jq
+	depends = dotnet-runtime
 	noextract = ASF-linux-x64.zip
 	options = !strip
-	source = https://github.com/JustArchiNET/ArchiSteamFarm/releases/download/4.0.1.9/ASF-linux-x64.zip
+	options = staticlibs
+	source = https://github.com/JustArchiNET/ArchiSteamFarm/releases/latest/download/ASF-linux-x64.zip
 	source = LICENSE-2.0.txt
 	source = ArchiSteamFarm-bin.desktop
-	md5sums = 26249accb2b892b30ea3b6cecb6c04bc
+	md5sums = SKIP
 	md5sums = 175792518e4ac015ab6696d16c4f607e
 	md5sums = 98654afd36cae629f570ff0510669ba2
 

--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = archisteamfarm-bin
 	pkgdesc = C# application that allows you to farm steam cards using multiple steam accounts simultaneously.
-	pkgver = 3.4.0.7
+	pkgver = 4.0.1.9
 	pkgrel = 1
 	url = https://github.com/JustArchiNET/ArchiSteamFarm
 	arch = x86_64
@@ -8,10 +8,10 @@ pkgbase = archisteamfarm-bin
 	makedepends = unzip
 	noextract = ASF-linux-x64.zip
 	options = !strip
-	source = https://github.com/JustArchiNET/ArchiSteamFarm/releases/download/3.4.0.7/ASF-linux-x64.zip
+	source = https://github.com/JustArchiNET/ArchiSteamFarm/releases/download/4.0.1.9/ASF-linux-x64.zip
 	source = LICENSE-2.0.txt
 	source = ArchiSteamFarm-bin.desktop
-	md5sums = cb87fd7001f5d2cbd9464321d8bcb668
+	md5sums = 26249accb2b892b30ea3b6cecb6c04bc
 	md5sums = 175792518e4ac015ab6696d16c4f607e
 	md5sums = 98654afd36cae629f570ff0510669ba2
 

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,37 +1,45 @@
 # Maintainer: Baron Hou <houbaron@gmail.com>
 
 pkgname=archisteamfarm-bin
-pkgver=4.0.1.9
+pkgver=4.1.1.7
 pkgrel=1
 pkgdesc="C# application that allows you to farm steam cards using multiple steam accounts simultaneously."
 arch=('x86_64')
 url="https://github.com/JustArchiNET/ArchiSteamFarm"
 license=("Apache License 2.0")
-makedepends=("unzip")
+depends=(dotnet-runtime)
+makedepends=("unzip" "curl" "jq")
 noextract=('ASF-linux-x64.zip')
-options=("!strip")
+options=("!strip" "staticlibs")
 
 source=(
-    "https://github.com/JustArchiNET/ArchiSteamFarm/releases/download/${pkgver}/ASF-linux-x64.zip"
+    "https://github.com/JustArchiNET/ArchiSteamFarm/releases/latest/download/ASF-linux-x64.zip"
     "LICENSE-2.0.txt"
     "ArchiSteamFarm-bin.desktop"
 )
 
 md5sums=(
-    '26249accb2b892b30ea3b6cecb6c04bc'
+    'SKIP'
     '175792518e4ac015ab6696d16c4f607e'
     '98654afd36cae629f570ff0510669ba2'
 )
 
+pkgver() {
+    curl -s https://api.github.com/repos/JustArchiNET/ArchiSteamFarm/releases/latest | jq -r '.tag_name'
+}
+
 prepare() {
-    unzip ASF-linux-x64.zip
-    rm -rf ASF-linux-x64.zip
+    rm -rf "ASF"
+    unzip ASF-linux-x64.zip -d "ASF"
 }
 
 package() {
     install -Dm644 "LICENSE-2.0.txt" "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
     install -Dm644 "ArchiSteamFarm-bin.desktop" "${pkgdir}/usr/share/applications/ArchiSteamFarm-bin.desktop"
 
-    install -Dm755 "ArchiSteamFarm" "${pkgdir}/opt/ArchiSteamFarm-bin/ArchiSteamFarm"
-    cp -r "${srcdir}"/* "${pkgdir}/opt/ArchiSteamFarm-bin/"
+    install -Dm755 "./ASF/ArchiSteamFarm" "${pkgdir}/opt/ArchiSteamFarm-bin/ArchiSteamFarm"
+    cp -r "${srcdir}/ASF"/* "${pkgdir}/opt/ArchiSteamFarm-bin/"
+
+    rm -f "$srcdir/../ASF-linux-x64.zip"
 }
+

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Baron Hou <houbaron@gmail.com>
 
 pkgname=archisteamfarm-bin
-pkgver=3.4.0.7
+pkgver=4.0.1.9
 pkgrel=1
 pkgdesc="C# application that allows you to farm steam cards using multiple steam accounts simultaneously."
 arch=('x86_64')
@@ -18,13 +18,14 @@ source=(
 )
 
 md5sums=(
-    'cb87fd7001f5d2cbd9464321d8bcb668'
+    '26249accb2b892b30ea3b6cecb6c04bc'
     '175792518e4ac015ab6696d16c4f607e'
     '98654afd36cae629f570ff0510669ba2'
 )
 
 prepare() {
     unzip ASF-linux-x64.zip
+    rm -rf ASF-linux-x64.zip
 }
 
 package() {


### PR DESCRIPTION
ArchiSteamFarm updates very frequently so this package will always install latest version. No need to do anything, just install it and that's it.
